### PR TITLE
Proposed new features: Aggregation can keep track of it's highest reached runstage

### DIFF
--- a/include/cpsCore/Aggregation/Aggregator.h
+++ b/include/cpsCore/Aggregation/Aggregator.h
@@ -10,6 +10,7 @@
 
 #include "cpsCore/Aggregation/DynamicContainer/DynamicObjectContainer.h"
 #include "cpsCore/Aggregation/IAggregatableObject.h"
+#include <cpsCore/Synchronization/IRunnableObject.h>
 
 #include <memory>
 #include <vector>
@@ -69,9 +70,26 @@ public:
 	void
 	cleanUp();
 
+	size_t
+	size() const;
+
+	void
+	signalRunBegin();
+
+	void
+	signalRunStageReached(const RunStage& runstage);
+
+	bool
+	runBegan() const;
+
+	RunStage
+	highestRunStage() const;
+
 private:
 
 	ObjectContainer container_;
+	bool runBegan_;
+	RunStage highestAchieved_;
 };
 
 template<class Type>
@@ -114,7 +132,7 @@ Aggregator::add(std::tuple<std::shared_ptr<Types>...> obj)
 {
 
 	std::apply([this](auto...x)
-			   { (this->add(x),...); }, obj);
+			   { (this->add(x), ...); }, obj);
 
 }
 

--- a/include/cpsCore/Aggregation/DynamicContainer/DynamicObjectContainer.h
+++ b/include/cpsCore/Aggregation/DynamicContainer/DynamicObjectContainer.h
@@ -37,8 +37,11 @@ public:
 	void
 	clear();
 
-	const std::vector<std::shared_ptr<IAggregatableObject> >&
-	getContainer() const;
+//	const std::vector<std::shared_ptr<IAggregatableObject> >&
+//	getContainer() const;
+
+	size_t
+	size() const;
 
 private:
 

--- a/include/cpsCore/Framework/StaticHelper.h
+++ b/include/cpsCore/Framework/StaticHelper.h
@@ -36,7 +36,7 @@ public:
 	 * @return Aggregator containing the objects
 	 */
 	inline static Aggregator
-	createAggregation(const Configuration& config)
+	createAggregation(const Configuration& config = Configuration())
 	{
 		Aggregator agg;
 		(addIfInConfig<Objects>(agg, config), ...);

--- a/include/cpsCore/Synchronization/IRunnableObject.h
+++ b/include/cpsCore/Synchronization/IRunnableObject.h
@@ -28,7 +28,7 @@
 
 enum class RunStage
 {
-	INIT, NORMAL, FINAL, SYNCHRONIZE
+	SYNCHRONIZE, INIT, NORMAL, FINAL
 };
 
 class IRunnableObject

--- a/include/cpsCore/Synchronization/SimpleRunner.h
+++ b/include/cpsCore/Synchronization/SimpleRunner.h
@@ -37,12 +37,12 @@ public:
 	SimpleRunner(Aggregator& agg);
 
 	bool
-	runStage(RunStage stage);
-
-	bool
 	runAllStages();
 
 private:
+
+	bool
+	runStage(RunStage stage);
 
 	Aggregator& agg_;
 };

--- a/src/Aggregation/Aggregator.cpp
+++ b/src/Aggregation/Aggregator.cpp
@@ -5,9 +5,10 @@
  *      Author: mircot
  */
 #include "cpsCore/Aggregation/Aggregator.h"
+#include "cpsCore/Logging/CPSLogger.h"
 
 
-Aggregator::Aggregator()
+Aggregator::Aggregator() : runBegan_(false), highestAchieved_(RunStage::INIT)
 {
 }
 
@@ -16,6 +17,15 @@ Aggregator::add(std::shared_ptr<IAggregatableObject> obj)
 {
 	container_.add(obj);
 	container_.notifyAggregationOnUpdate(*this);
+}
+
+void
+Aggregator::add(std::vector<std::shared_ptr<IAggregatableObject>> objs)
+{
+	for (auto it : objs)
+	{
+		add(it);
+	}
 }
 
 Aggregator
@@ -60,11 +70,40 @@ Aggregator::cleanUp()
 	clear();
 }
 
-void
-Aggregator::add(std::vector<std::shared_ptr<IAggregatableObject>> objs)
+size_t
+Aggregator::size() const
 {
-	for (auto it : objs)
+	return container_.size();
+}
+
+void
+Aggregator::signalRunBegin()
+{
+	runBegan_ = true;
+}
+
+void
+Aggregator::signalRunStageReached(const RunStage& runstage)
+{
+	if (runstage > highestAchieved_)
 	{
-		add(it);
+		highestAchieved_ = runstage;
 	}
+	else
+	{
+		//TODO Give RunStages string representation
+		CPSLOG_WARN << "Signaled RunStage " << (int) runstage << " has already been reached.";
+	}
+}
+
+bool
+Aggregator::runBegan() const
+{
+	return runBegan_;
+}
+
+RunStage
+Aggregator::highestRunStage() const
+{
+	return highestAchieved_;
 }

--- a/src/Aggregation/DynamicContainer/DynamicObjectContainer.cpp
+++ b/src/Aggregation/DynamicContainer/DynamicObjectContainer.cpp
@@ -32,14 +32,20 @@ DynamicObjectContainer::notifyAggregationOnUpdate(const Aggregator& agg)
 void
 DynamicObjectContainer::add(const DynamicObjectContainer& obj)
 {
-	for (auto it : obj.getContainer())
+	for (auto it : obj.container_)
 	{
 		container_.push_back(it);
 	}
 }
 
-const std::vector<std::shared_ptr<IAggregatableObject> >&
-DynamicObjectContainer::getContainer() const
+//const std::vector<std::shared_ptr<IAggregatableObject> >&
+//DynamicObjectContainer::getContainer() const
+//{
+//	return container_;
+//}
+
+size_t
+DynamicObjectContainer::size() const
 {
-	return container_;
+	return container_.size();
 }

--- a/src/Framework/api/FrameworkAPI.cpp
+++ b/src/Framework/api/FrameworkAPI.cpp
@@ -21,7 +21,7 @@ std::unique_lock<std::mutex>
 FrameworkAPI::lockAggregator()
 {
 	std::unique_lock<std::mutex> lock(instance()->aggMutex_);
-	return std::move(lock);
+	return lock;
 }
 
 Aggregator*

--- a/src/Synchronization/SimpleRunner.cpp
+++ b/src/Synchronization/SimpleRunner.cpp
@@ -41,6 +41,7 @@ SimpleRunner::runStage(RunStage stage)
 		if (it->run(stage))
 			error = true;
 	}
+	agg_.signalRunStageReached(stage);
 	CPSLogger::instance()->flush(); //Synchronize stdio
 	return error;
 }
@@ -48,6 +49,7 @@ SimpleRunner::runStage(RunStage stage)
 bool
 SimpleRunner::runAllStages()
 {
+	agg_.runBegan();
 	CPSLOG_DEBUG << "Run stage INIT";
 	if (runStage(RunStage::INIT))
 	{


### PR DESCRIPTION
Proposed Changes

- Aggregator keeps track of highest runstage achieved, and if runstages have began. I believe such aggregator state is important to keep track of, and I intend to use it in my XPlaneInterface to see if the node has started.
- SimpeRunner and SyncronizedRunner are responsible to notify Aggregator if a runstage has started (but that is okay because they are part of cpsCore and we have full control over it. However, I think we should merge the runner and aggregator, because they seem inherently tied together)
- SimpleRunner inividual runstage is private. Nobody else should be calling individual runstages.
- DynamicObjectContainer::getContainer() is removed. As a general rule of thumb, it is a bad OO practice to chain getters and do things like a->getb()->getc()->getd()->...->operation(). While so far we don't have that, this function seems like it would encourage such programming.