### PR TITLE
Adding fixes to allow compiling on gcc10

### DIFF
--- a/include/cpsCore/Utilities/IPC/detail/MessageQueueSubscriptionImpl.h
+++ b/include/cpsCore/Utilities/IPC/detail/MessageQueueSubscriptionImpl.h
@@ -8,6 +8,7 @@
 #ifndef UAVAP_CORE_IPC_DETAIL_MESSAGEQUEUESUBSCRIPTIONIMPL_H_
 #define UAVAP_CORE_IPC_DETAIL_MESSAGEQUEUESUBSCRIPTIONIMPL_H_
 #include <thread>
+#include <atomic>
 
 #include <boost/interprocess/ipc/message_queue.hpp>
 

--- a/include/cpsCore/Utilities/IPC/detail/SharedMemorySubscriptionImpl.h
+++ b/include/cpsCore/Utilities/IPC/detail/SharedMemorySubscriptionImpl.h
@@ -9,6 +9,7 @@
 #define UAVAP_CORE_IPC_DETAIL_SHAREDMEMORYSUBSCRIPTIONIMPL_H_
 
 #include <thread>
+#include <atomic>
 
 #include <boost/interprocess/shared_memory_object.hpp>
 

--- a/tests/Utilities/IPC/IPCTest.cpp
+++ b/tests/Utilities/IPC/IPCTest.cpp
@@ -75,9 +75,9 @@ TEST_CASE("IPC Test 1")
 	int counter1 = 0;
 	int counter2 = 0;
 	Subscription sub1 = ipc->subscribe<Test>("test",
-											 boost::bind(&checkValue, _1, boost::ref(counter1)));
+											 boost::bind(&checkValue, boost::placeholders::_1, boost::ref(counter1)));
 	Subscription sub2 = ipc->subscribe<Test>("test",
-											 boost::bind(&checkValue, _1, boost::ref(counter2)));
+											 boost::bind(&checkValue, boost::placeholders::_1, boost::ref(counter2)));
 	REQUIRE(sub1.connected());
 	REQUIRE(sub2.connected());
 	SimpleRunner run(agg);


### PR DESCRIPTION
I installed gcc7 on Arch, but I was still getting the same compile issues. I added these fixes to allow cpsCore to compile on my system, and the tests pass on both my Ubuntu virtual machine, as well as both gcc7 and gcc10 on Arch